### PR TITLE
fix py install path

### DIFF
--- a/.ci_support/migrations/wcslib77.yaml
+++ b/.ci_support/migrations/wcslib77.yaml
@@ -1,8 +1,0 @@
-migrator_ts: 1651431249
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-
-wcslib:
-  - '7.7'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ version: 2
 jobs:
   build:
     working_directory: ~/test
-    machine: true
+    machine:
+      image: ubuntu-2004:current
     steps:
       - run:
           # The Circle-CI build should not be active, but if this is not true for some reason, do a fast finish.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -24,7 +24,10 @@ export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
 cat >~/.condarc <<CONDARC
 
 conda-build:
- root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+  root-dir: ${FEEDSTOCK_ROOT}/build_artifacts
+pkgs_dirs:
+  - ${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache
+  - /opt/conda/pkgs
 
 CONDARC
 
@@ -45,6 +48,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null
+
+if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
+  cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
+fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -57,6 +57,10 @@ echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
 
+if [[ -f LICENSE.txt ]]; then
+  cp LICENSE.txt "recipe/recipe-scripts-license.txt"
+fi
+
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,27 @@
-BSD 3-clause license
+BSD-3-Clause license
 Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+  3. Neither the name of the copyright holder nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/build-locally.py
+++ b/build-locally.py
@@ -86,12 +86,19 @@ def main(args=None):
     verify_config(ns)
     setup_environment(ns)
 
-    if ns.config.startswith("linux") or (
-        ns.config.startswith("osx") and platform.system() == "Linux"
-    ):
-        run_docker_build(ns)
-    elif ns.config.startswith("osx"):
-        run_osx_build(ns)
+    try:
+        if ns.config.startswith("linux") or (
+            ns.config.startswith("osx") and platform.system() == "Linux"
+        ):
+            run_docker_build(ns)
+        elif ns.config.startswith("osx"):
+            run_osx_build(ns)
+    finally:
+        recipe_license_file = os.path.join(
+            "recipe", "recipe-scripts-license.txt"
+        )
+        if os.path.exists(recipe_license_file):
+            os.remove(recipe_license_file)
 
 
 if __name__ == "__main__":

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,8 +32,7 @@ export WCSLIB_INC="-I$PREFIX/include -I$PREFIX/include/wcslib"
 export WCSLIB_LIB="-L$PREFIX/lib -lwcs"
 
 export INSTALL_DIR="$PREFIX"
-export PY_VER=$(python -c "from sys import version_info as v; print('python%i.%i' % (v.major,v.minor))")
-export PY_BASE_INSTALL_DIR=$INSTALL_DIR/lib/$PY_VER/astrometry
+export PY_BASE_INSTALL_DIR=$SP_DIR/astrometry
 
 # Making process
 make -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,6 +31,9 @@ export GSL_LIB="-L$PREFIX/lib -lgsl"
 export WCSLIB_INC="-I$PREFIX/include -I$PREFIX/include/wcslib"
 export WCSLIB_LIB="-L$PREFIX/lib -lwcs"
 
+PY_VER ?= $(shell $(PYTHON) -c "from sys import version_info as v; print('python%i.%i' % (v.major,v.minor))")
+export PY_BASE_INSTALL_DIR ?= $(INSTALL_DIR)/lib/$(PY_VER)/astrometry
+
 # Making process
 make -j${CPU_COUNT}
 make extra

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,8 +31,8 @@ export GSL_LIB="-L$PREFIX/lib -lgsl"
 export WCSLIB_INC="-I$PREFIX/include -I$PREFIX/include/wcslib"
 export WCSLIB_LIB="-L$PREFIX/lib -lwcs"
 
-PY_VER ?= $(shell $(PYTHON) -c "from sys import version_info as v; print('python%i.%i' % (v.major,v.minor))")
-export PY_BASE_INSTALL_DIR ?= $(INSTALL_DIR)/lib/$(PY_VER)/astrometry
+export PY_VER=$(python -c "from sys import version_info as v; print('python%i.%i' % (v.major,v.minor))")
+export PY_BASE_INSTALL_DIR=$INSTALL_DIR/lib/$PY_VER/astrometry
 
 # Making process
 make -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,7 +32,7 @@ export WCSLIB_INC="-I$PREFIX/include -I$PREFIX/include/wcslib"
 export WCSLIB_LIB="-L$PREFIX/lib -lwcs"
 
 export INSTALL_DIR="$PREFIX"
-export PY_BASE_INSTALL_DIR=$SP_DIR/astrometry
+export PY_BASE_INSTALL_DIR="$SP_DIR/astrometry"
 
 # Making process
 make -j${CPU_COUNT}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -31,6 +31,7 @@ export GSL_LIB="-L$PREFIX/lib -lgsl"
 export WCSLIB_INC="-I$PREFIX/include -I$PREFIX/include/wcslib"
 export WCSLIB_LIB="-L$PREFIX/lib -lwcs"
 
+export INSTALL_DIR="$PREFIX"
 export PY_VER=$(python -c "from sys import version_info as v; print('python%i.%i' % (v.major,v.minor))")
 export PY_BASE_INSTALL_DIR=$INSTALL_DIR/lib/$PY_VER/astrometry
 
@@ -38,7 +39,7 @@ export PY_BASE_INSTALL_DIR=$INSTALL_DIR/lib/$PY_VER/astrometry
 make -j${CPU_COUNT}
 make extra
 make py
-make install INSTALL_DIR="$PREFIX"
+make install
 
 # Move the default configuration file to avoid user config overwritten
 mkdir -p "$PREFIX/share/astrometry"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 16f02686c3e19d3fb1d56c9ede3fd6cd62a13f7b429e9c6653f52f17edc7227a
 
 build:
-  number: 3
+  number: 2
   skip: true  # [win]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 16f02686c3e19d3fb1d56c9ede3fd6cd62a13f7b429e9c6653f52f17edc7227a
 
 build:
-  number: 1
+  number: 3
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Fixes #29 

This patch resolves the problem that `astrometry` library is getting installed at `lib/python` instead of `lib/python3.x` by setting manually the install path.
