### PR TITLE
Migrate to most recent cfitsio pin (4.6.2)

### DIFF
--- a/.ci_support/linux_64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/linux_64_numpy2.0python3.10.____cpython.yaml
@@ -13,7 +13,7 @@ cairo:
 cdt_name:
 - conda
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/linux_64_numpy2.0python3.11.____cpython.yaml
@@ -13,7 +13,7 @@ cairo:
 cdt_name:
 - conda
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/linux_64_numpy2.0python3.12.____cpython.yaml
@@ -13,7 +13,7 @@ cairo:
 cdt_name:
 - conda
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_numpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy2.0python3.9.____cpython.yaml
@@ -13,7 +13,7 @@ cairo:
 cdt_name:
 - conda
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/linux_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/linux_64_numpy2python3.13.____cp313.yaml
@@ -13,7 +13,7 @@ cairo:
 cdt_name:
 - conda
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/migrations/cfitsio441.yaml
+++ b/.ci_support/migrations/cfitsio441.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for cfitsio 4.4.1
-  kind: version
-  migration_number: 1
-cfitsio:
-- 4.4.1
-migrator_ts: 1718934381.4672027

--- a/.ci_support/migrations/cfitsio450.yaml
+++ b/.ci_support/migrations/cfitsio450.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for cfitsio 4.5.0
-  kind: version
-  migration_number: 1
-cfitsio:
-- 4.5.0
-migrator_ts: 1734919906.7875106

--- a/.ci_support/migrations/cfitsio462.yaml
+++ b/.ci_support/migrations/cfitsio462.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for cfitsio 4.6.2
+  kind: version
+  migration_number: 1
+cfitsio:
+- 4.6.2
+migrator_ts: 1743652730.340723

--- a/.ci_support/osx_64_numpy2.0python3.10.____cpython.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.10.____cpython.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cairo:
 - '1'
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_numpy2.0python3.11.____cpython.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.11.____cpython.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cairo:
 - '1'
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_numpy2.0python3.12.____cpython.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.12.____cpython.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cairo:
 - '1'
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_numpy2.0python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy2.0python3.9.____cpython.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cairo:
 - '1'
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_numpy2python3.13.____cp313.yaml
+++ b/.ci_support/osx_64_numpy2python3.13.____cp313.yaml
@@ -15,7 +15,7 @@ c_stdlib_version:
 cairo:
 - '1'
 cfitsio:
-- 4.6.0
+- 4.6.2
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: e4eef1b658ba5ad462282b661c0ca3a5c538ba1716e853f7970b7b9fa4a33459
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
     - xorg-libxau
     - xorg-libxext
     - xorg-libxrender
-    - xorg-xproto
+    - xorg-xorgproto
     - zlib
     - libjpeg-turbo
     - netpbm


### PR DESCRIPTION
The migrator couldn't solve this because we also need to switch to using `xorg-xorgproto` rather than `xorg-xproto`.

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
